### PR TITLE
ci: publish Docker images to GHCR (from CircleCI)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 
 references:
   production_context: &production_context
-    - docker
+    - ghcr
     - github
   pypi_context: &pypi_context
     - pypi
@@ -103,16 +103,18 @@ jobs:
             VERSION=$(uv version --short)
             echo "export VERSION=$VERSION" >> $BASH_ENV
             echo "Building version: $VERSION"
+      - run:
+          name: Log in to GHCR
+          command: echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
       - attach_workspace:
           at: .
       - sre/build-docker:
           dockerfile: './docker/Dockerfile'
-          image_name: 'tracktor/padmy'
+          image_name: 'ghcr.io/tracktor/padmy'
           tag: <<# parameters.include_network >>${VERSION}-network-<< parameters.pg_version >><</ parameters.include_network >><<^ parameters.include_network >>${VERSION}-<< parameters.pg_version >><</ parameters.include_network >>
           latest_tag: <<# parameters.include_network >>latest-network-<< parameters.pg_version >><</ parameters.include_network >><<^ parameters.include_network >>latest-<< parameters.pg_version >><</ parameters.include_network >>
+          cache_tag: <<# parameters.include_network >>cache-network-<< parameters.pg_version >><</ parameters.include_network >><<^ parameters.include_network >>cache-<< parameters.pg_version >><</ parameters.include_network >>
           publish: true
-          registry_pwd: $CONTAINER_REGISTRY_PWD
-          registry_user: $CONTAINER_REGISTRY_USER
           build_params: --build-arg PG_VERSION=<< parameters.pg_version >><<# parameters.include_network >> --build-arg UV_PARAMS="--group network"<</ parameters.include_network >>
 
 


### PR DESCRIPTION
## Summary
Migrates the Docker publish step from Docker Hub (`tracktor/padmy`) to GitHub Container Registry (`ghcr.io/tracktor/padmy`). Everything stays in CircleCI — same `build-publish-docker` matrix (PG 15/16/17/18 × `{plain, network}`), same tag scheme, same triggers (release tags only).

## Changes
- `image_name: ghcr.io/tracktor/padmy`
- Explicit `docker login ghcr.io` step before the orb call (the orb's built-in login is hardcoded to Docker Hub).
- Per-variant `cache_tag` (`cache-<pg>`, `cache-network-<pg>`) so the 8 matrix builds don't trash each other's BuildKit cache.
- Publish context renamed `docker` → `ghcr`.

## CircleCI setup required before merge
Create (or rename) a `ghcr` context with:
- `GHCR_USER` — a GitHub username (your bot account or a personal account)
- `GHCR_TOKEN` — a PAT (classic or fine-grained) with `write:packages` scope on the `Tracktor` org

## Tag layout (unchanged)
- `<version>-<pg>`, `latest-<pg>`
- `<version>-network-<pg>`, `latest-network-<pg>`

## Test plan
- [ ] Create the `ghcr` CircleCI context with `GHCR_USER` / `GHCR_TOKEN`
- [ ] Merge to master
- [ ] Cut a `cz bump` release and confirm 8 images land at `ghcr.io/tracktor/padmy`
- [ ] In the package settings, link the package to the repo and set visibility (defaults to private)

## Follow-ups (not in this PR)
- Revoke the old Docker Hub credentials once GHCR is confirmed working.
- Update any README/docs that reference the Docker Hub image name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)