### PR TITLE
fix(sample,anonymize): honor ignore tables, target overrides, empty fields

### DIFF
--- a/padmy/config.py
+++ b/padmy/config.py
@@ -65,7 +65,7 @@ class ConfigTable:
 
     @property
     def has_ano_fields(self):
-        return self.fields is not None
+        return bool(self.fields)
 
     @classmethod
     def load(cls, table: dict):

--- a/padmy/sampling/sampling.py
+++ b/padmy/sampling/sampling.py
@@ -268,8 +268,8 @@ async def sample_database(
         logs.info("Creating temporary tables")
         await create_temp_tables(conn, db.tables)
 
-        # Safety check
-        _not_processed_tables = [x.full_name for x in db.tables if not x.has_been_processed]
+        # Safety check + ignore tables
+        _not_processed_tables = [x.full_name for x in db.tables if not x.has_been_processed and not x.ignore]
         if _not_processed_tables:
             raise NotImplementedError(
                 f"Found {len(_not_processed_tables)} tables that has not been "
@@ -280,6 +280,8 @@ async def sample_database(
         if show_progress:
             logs.info("Loading tables count")
             for table in db.tables:
+                if table.ignore:
+                    continue
                 _count = await conn.fetchval(f"SELECT count(*) from {table.tmp_name}")
                 if _count is None:
                     raise ValueError("Got empty count")
@@ -291,6 +293,11 @@ async def sample_database(
                 task1 = progress.add_task("[green]Inserting tables....", total=len(db.tables))
                 task2 = progress.add_task("[purple]Inserting chunks....") if show_progress else None
                 for table in db.tables:
+                    # Skip ignored tables — they have no temp table and we
+                    # don't want them in the sampled output.
+                    if table.ignore:
+                        progress.update(task1, advance=1)
+                        continue
                     logs.debug(f"Inserting to {table.full_name}")
                     if task2 is not None:
                         progress.reset(task2, total=_table_count[table.tmp_name])

--- a/padmy/utils.py
+++ b/padmy/utils.py
@@ -167,12 +167,20 @@ def create_ssl_context(
 
 
 def get_pg_envs():
+    """Build the libpq env dict passed to subprocess calls (pg_dump, createdb, …).
+
+    Prefer values already set in os.environ — `PGConnectionInfo.temp_env`
+    populates PGHOST/PGPORT/PGUSER/PGPASSWORD inside its `with` block so that
+    `--host-to` / `PG_PORT_TO` overrides flow through. Falling back to the
+    `env` module defaults (PG_HOST / PG_PORT) only when libpq vars aren't set
+    keeps the standalone CLI path working.
+    """
     reload(env)
     envs = {
-        "PGPASSWORD": env.PG_PASSWORD,
-        "PGUSER": env.PG_USER,
-        "PGHOST": env.PG_HOST,
-        "PGPORT": str(env.PG_PORT),
+        "PGPASSWORD": os.environ.get("PGPASSWORD", env.PG_PASSWORD),
+        "PGUSER": os.environ.get("PGUSER", env.PG_USER),
+        "PGHOST": os.environ.get("PGHOST", env.PG_HOST),
+        "PGPORT": os.environ.get("PGPORT", str(env.PG_PORT)),
     }
     # Add SSL environment variables if configured
     if PG_SSL_MODE:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -149,3 +149,17 @@ def test_load_config():
     )
     config = Config.load(sample=20, schemas=["schema_1", "schema_2"])
     assert asdict(config) == asdict(expected), pprint_dataclass_diff(config, expected)
+
+
+def test_has_ano_fields_false_when_no_fields():
+    from padmy.config import ConfigTable
+
+    assert ConfigTable(schema="public", table="t").has_ano_fields is False
+    assert ConfigTable(schema="public", table="t", fields=[]).has_ano_fields is False
+
+
+def test_has_ano_fields_true_when_fields_present():
+    from padmy.config import AnoFields, ConfigTable
+
+    t = ConfigTable(schema="public", table="t", fields=[AnoFields(column="email", type="EMAIL")])
+    assert t.has_ano_fields is True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -348,3 +348,33 @@ class TestErrorMessageExtraction:
         from padmy.utils import extract_pg_error
 
         assert extract_pg_error(data) == expected
+
+
+class TestGetPgEnvs:
+    def test_honors_temp_env_overrides(self, monkeypatch):
+        # temp_env sets PGHOST/PGPORT/... in os.environ; get_pg_envs must
+        # surface those, otherwise --host-to / --port-to are silently lost.
+        from padmy.utils import PGConnectionInfo, get_pg_envs
+
+        for k in ("PGHOST", "PGPORT", "PGUSER", "PGPASSWORD"):
+            monkeypatch.delenv(k, raising=False)
+
+        info = PGConnectionInfo(pg_host="target.example", pg_port=6543, pg_user="alice", pg_password="s3cret")
+        with info.temp_env(include_database=False):
+            envs = get_pg_envs()
+
+        assert envs["PGHOST"] == "target.example"
+        assert envs["PGPORT"] == "6543"
+        assert envs["PGUSER"] == "alice"
+        assert envs["PGPASSWORD"] == "s3cret"
+
+    def test_falls_back_to_env_module_defaults(self, monkeypatch):
+        from padmy.utils import get_pg_envs
+
+        for k in ("PGHOST", "PGPORT", "PGUSER", "PGPASSWORD"):
+            monkeypatch.delenv(k, raising=False)
+
+        envs = get_pg_envs()
+        # env.PG_HOST defaults to "localhost", env.PG_PORT to 5432
+        assert envs["PGHOST"] == "localhost"
+        assert envs["PGPORT"] == "5432"


### PR DESCRIPTION
## Summary

Three bugs surfaced while wiring padmy into a real prod sample-and-anonymize pipeline. All three were silent footguns rather than crashes at obvious places, and each blocked a legitimate-looking config from working.

### 1. `ignore: true` tables broke sampling
With any `tables: [{ schema: x, table: y, ignore: true }]` entry:
- After `process_table` skipped ignored tables, the safety check at the end of `sample_database` fired: `Found N tables that has not been processed: ...`
- If you got past the safety check, the insert loop tried to `SELECT … FROM _ignored_table_tmp` and crashed with `relation "_…_tmp" does not exist`.

The "ignored" filter was applied in `child_tables_safe` / `parent_tables_safe` (good) but the bookkeeping/insert passes iterated all `db.tables` directly. Excluded ignored tables from:
- the post-sampling safety check (`sampling.py:272`)
- the temp-table count pass (line ~284)
- the insert loop (line ~295)

### 2. `--host-to` / `--port-to` silently ignored by `createdb` / `dropdb`
With `padmy sample --copy-db --host-to A --port-to 6543` (or `PG_HOST_TO`/`PG_PORT_TO`), the scratch DB landed on the **source** host/port, not the target.

`PGConnectionInfo.temp_env` sets the libpq env vars (`PGHOST`/`PGPORT`/`PGUSER`/`PGPASSWORD`) on `os.environ` so subprocesses pick them up. But `get_pg_envs()` rebuilt the env dict from `env.PG_HOST` / `env.PG_PORT` — padmy's own env vars, which only get read at module load from `PG_HOST` / `PG_PORT` (no _FROM/_TO suffix). So target overrides flowed into the asyncpg side but never reached `createdb`/`dropdb`.

Made `get_pg_envs` prefer the libpq vars in `os.environ`, falling back to the env-module defaults so existing standalone-CLI usage still works.

### 3. Empty `fields` list crashed `anonymize`
`has_ano_fields` returned True for any `ConfigTable` because `fields = field(default_factory=list)` and `[] is not None == True`. So if a config had a table entry with no anonymize fields (e.g. just a sample rate), `anonymize_db` would try to anonymize it and emit `UPDATE … SET (empty) FROM (VALUES (…)) AS u2(id) WHERE u2.id = u.id` → `syntax error at or near "from"`.

Fixed `has_ano_fields` to `bool(self.fields)`.

## Tests

4 new unit cases in `tests/test_config.py` and `tests/test_utils.py`:
- `test_has_ano_fields_false_when_no_fields` / `test_has_ano_fields_true_when_fields_present`
- `TestGetPgEnvs::test_honors_temp_env_overrides` / `test_falls_back_to_env_module_defaults`

End-to-end validation against a local postgres confirmed: sample → anonymize cycle with `ignore: true` + `--host-to`/`--port-to` + a table with no `fields` all succeed.

## Test plan
- [ ] CI green
- [ ] Smoke against a real DB: `padmy sample --copy-db --host-to <other> --port-to <p>` lands on `<other>:<p>`