### PR TITLE
feat(anonymize): publish anonymize as a pip extra + anon docker images

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -10,6 +10,7 @@ group "default" {
   targets = [
     "pg15", "pg16", "pg17", "pg18",
     "pg15-network", "pg16-network", "pg17-network", "pg18-network",
+    "pg15-anonymize", "pg16-anonymize", "pg17-anonymize", "pg18-anonymize",
   ]
 }
 
@@ -70,4 +71,28 @@ target "pg18-network" {
   inherits = ["_common"]
   args     = { PG_VERSION = "18", UV_PARAMS = "--group network" }
   tags     = ["${REGISTRY}/padmy:${VERSION}-network-18", "${REGISTRY}/padmy:latest-network-18"]
+}
+
+target "pg15-anonymize" {
+  inherits = ["_common"]
+  args     = { PG_VERSION = "15", UV_PARAMS = "--extra anonymize" }
+  tags     = ["${REGISTRY}/padmy:${VERSION}-anonymize-15", "${REGISTRY}/padmy:latest-anonymize-15"]
+}
+
+target "pg16-anonymize" {
+  inherits = ["_common"]
+  args     = { PG_VERSION = "16", UV_PARAMS = "--extra anonymize" }
+  tags     = ["${REGISTRY}/padmy:${VERSION}-anonymize-16", "${REGISTRY}/padmy:latest-anonymize-16"]
+}
+
+target "pg17-anonymize" {
+  inherits = ["_common"]
+  args     = { PG_VERSION = "17", UV_PARAMS = "--extra anonymize" }
+  tags     = ["${REGISTRY}/padmy:${VERSION}-anonymize-17", "${REGISTRY}/padmy:latest-anonymize-17"]
+}
+
+target "pg18-anonymize" {
+  inherits = ["_common"]
+  args     = { PG_VERSION = "18", UV_PARAMS = "--extra anonymize" }
+  tags     = ["${REGISTRY}/padmy:${VERSION}-anonymize-18", "${REGISTRY}/padmy:latest-anonymize-18"]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,13 @@ dependencies = [
     "pytz >=2024.1,<2025.0 ; python_version < '3.12'"
 ]
 
+# Published extras so consumers can `pip install padmy[anonymize]`.
+# The matching [dependency-groups] entry below stays for local uv workflows.
+[project.optional-dependencies]
+anonymize = [
+    "Faker >=13.15.1,<14.0.0",
+]
+
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1310,6 +1310,11 @@ dependencies = [
     { name = "tracktolib" },
 ]
 
+[package.optional-dependencies]
+anonymize = [
+    { name = "faker" },
+]
+
 [package.dev-dependencies]
 anonymize = [
     { name = "faker" },
@@ -1339,12 +1344,14 @@ notebook = [
 [package.metadata]
 requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0,<1.0.0" },
+    { name = "faker", marker = "extra == 'anonymize'", specifier = ">=13.15.1,<14.0.0" },
     { name = "piou", specifier = ">=0.21.0,<1.0.0" },
     { name = "pytz", marker = "python_full_version < '3.12'", specifier = ">=2024.1,<2025.0" },
     { name = "pyyaml", specifier = ">=6.0.2,<7.0" },
     { name = "tracktolib", specifier = ">=0.42.1,<1.0.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.3.0" },
 ]
+provides-extras = ["anonymize"]
 
 [package.metadata.requires-dev]
 anonymize = [{ name = "faker", specifier = ">=13.15.1,<14.0.0" }]


### PR DESCRIPTION
## Why

`padmy anonymize` requires Faker, but Faker was declared only under `[dependency-groups]` (PEP 735), which is **not** published in wheel metadata. Consequences:

- `pip install padmy[anonymize]` was a no-op (no such extra) — the runtime error hint *"install … padmy with 'anonymize'"* was misleading.
- The prebuilt images (`latest-N`) were built without the group, so `padmy anonymize` fails at runtime with `ImportError: Please install faker or padmy with "anonymize"`.

This surfaced while wiring up the Obitrain `sample-db` cronjob, which runs `padmy sample` + `padmy anonymize` from `ghcr.io/getsoren/padmy:latest-17`.

## Changes

1. **`pyproject.toml`** — add `[project.optional-dependencies] anonymize = ["Faker >=13.15.1,<14.0.0"]` so the extra is publishable and `pip install padmy[anonymize]` works. The existing `[dependency-groups] anonymize` stays for local uv workflows.
2. **`docker-bake.hcl`** — add `pg{15,16,17,18}-anonymize` targets (`UV_PARAMS="--extra anonymize"`) producing `:${VERSION}-anonymize-N` / `:latest-anonymize-N` tags, mirroring the `-network` variants.
3. **`uv.lock`** — regenerated for the new extra.

## Verification

Built `pg17-anonymize` locally (linux/amd64):

```
$ docker run --rm --entrypoint python padmy:anon-test -c "import faker; print(faker.VERSION)"
13.16.0
$ docker run --rm --entrypoint python ghcr.io/getsoren/padmy:0.27.1-17 -c "import faker"
ModuleNotFoundError: No module named 'faker'
```

After the next release, `ghcr.io/getsoren/padmy:latest-anonymize-17` will carry Faker; the Obitrain `sample-db` job will switch to it and drop its `pip install faker` stopgap.