### PR TITLE
feat(anonymize): add unique option to anonymized fields

### DIFF
--- a/padmy/anonymize/anonymize.py
+++ b/padmy/anonymize/anonymize.py
@@ -11,6 +11,7 @@ import asyncpg
 
 if TYPE_CHECKING:
     from faker import Faker
+    from faker.proxy import UniqueProxy
 
 from padmy.logs import logs
 from ..config import Config, ConfigTable, FieldType, AnoFields
@@ -36,7 +37,7 @@ def get_update_query(table: str, pks: list[str], fields: list[str], field_types:
     return query
 
 
-def _get_fake_value(faker: Faker, field: FieldType, extra_fields: dict | None = None) -> Any:
+def _get_fake_value(faker: Faker | UniqueProxy, field: FieldType, extra_fields: dict | None = None) -> Any:
     _extra_fields = extra_fields or {}
     match field:
         case "EMAIL":
@@ -66,7 +67,7 @@ def _get_fake_value(faker: Faker, field: FieldType, extra_fields: dict | None = 
 
 def gen_mock_data(faker: Faker, fields: list[AnoFields], size: int) -> Iterator[dict]:
     for _ in range(size):
-        yield {v.column: _get_fake_value(faker, v.type, v.extra_args) for v in fields}
+        yield {v.column: _get_fake_value(faker.unique if v.unique else faker, v.type, v.extra_args) for v in fields}
 
 
 def dict_to_tuple(d: dict, fields: list[str]) -> tuple:

--- a/padmy/config.py
+++ b/padmy/config.py
@@ -31,6 +31,8 @@ class AnoFields:
     column: str
     type: FieldType
     extra_args: dict | None = None
+    # Generate values through faker.unique (for columns with a unique constraint)
+    unique: bool = False
 
     @classmethod
     def load(cls, data: dict):
@@ -38,12 +40,14 @@ class AnoFields:
             column = next(iter(data))
             _type = data[column]
             extra_args = None
+            unique = False
         else:
             column = data.pop("column")
             _type = data.pop("type")
+            unique = data.pop("unique", False)
             extra_args = data if data else None
 
-        return AnoFields(column=column, type=_type, extra_args=extra_args)
+        return AnoFields(column=column, type=_type, extra_args=extra_args, unique=unique)
 
 
 @dataclass

--- a/tests/test_anonymize.py
+++ b/tests/test_anonymize.py
@@ -98,6 +98,16 @@ def test_get_fake_value(faker, field_type, extra, predicate):
     assert predicate(value), f"unexpected value for {field_type}: {value!r}"
 
 
+def test_gen_mock_data_unique(faker):
+    """unique fields never repeat a value, even across chunks (see users_email_key incident)."""
+    from padmy.anonymize.anonymize import gen_mock_data
+    from padmy.config import AnoFields
+
+    fields = [AnoFields(column="email", type="EMAIL", unique=True)]
+    values = [row["email"] for _ in range(5) for row in gen_mock_data(faker, fields=fields, size=200)]
+    assert len(set(values)) == len(values)
+
+
 def test_get_fake_value_unknown_type_raises(faker):
     from padmy.anonymize.anonymize import _get_fake_value
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,6 +98,38 @@ def get_custom_fields_expected():
     return expected
 
 
+CONFIG_UNIQUE_FIELDS = """
+tables:
+  - schema: public
+    table: table_1
+    fields:
+      - column: bar
+        type: EMAIL
+        unique: true
+        domain_name: soren.fr
+"""
+
+
+def get_unique_fields_expected():
+    expected = Config(
+        tables=[
+            ConfigTable(
+                schema="public",
+                table="table_1",
+                fields=[
+                    AnoFields(
+                        column="bar",
+                        type="EMAIL",
+                        extra_args={"domain_name": "soren.fr"},
+                        unique=True,
+                    )
+                ],
+            ),
+        ],
+    )
+    return expected
+
+
 CONFIG_IGNORE = """
 tables:
   - schema: public
@@ -121,6 +153,7 @@ def get_ignore_table_expected():
         pytest.param(CONFIG_LITE, get_config_lite_expected(), id="Config lite"),
         pytest.param(CONFIG_FULL, get_config_full_expected(), id="Config full"),
         pytest.param(CONFIG_CUSTOM_TABLE_FIELDS, get_custom_fields_expected(), id="Custom fields"),
+        pytest.param(CONFIG_UNIQUE_FIELDS, get_unique_fields_expected(), id="Unique fields"),
         pytest.param(CONFIG_IGNORE, get_ignore_table_expected(), id="Config ignore"),
     ],
 )


### PR DESCRIPTION
## Why

Plain `faker.email()` draws from a small pool (`{name}{##}@example.{tld}`), so anonymizing a few thousand rows makes birthday-paradox collisions on unique columns a matter of time.

## What

- New `unique: true` option on anonymized fields (`AnoFields`), routing generation through `faker.unique` which guarantees no repeated values per process.
- Works with extra args, e.g.:

```yaml
fields:
  - column: email
    type: EMAIL
    unique: true
```

- Tests: config parsing of the flag + no-duplicates guarantee across chunks.

Note: `faker.unique` raises `UniquenessException` after 1000 consecutive retries — not a concern at current table sizes, and a loud failure beats a silent constraint violation.