### PR TITLE
ci: use the org-wide SOREN_PAT (replaces BUMP_TOKEN)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BUMP_TOKEN }}
+          token: ${{ secrets.SOREN_PAT }}
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       - name: Install bump tools
         run: uv sync --locked --group bump


### PR DESCRIPTION
Part of consolidating release tokens on the org-wide `SOREN_PAT` (removing `BUMP_TOKEN`). NB: requires the SOREN_PAT token's repository access to include this repo.