### PR TITLE
fix(sampling): eliminate multiplicative FK-closure joins, add COPY transfer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,7 +155,6 @@ cython_debug/
 
 requirements.txt
 image.tar
-scratch/
 .scratch/
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,7 @@ cython_debug/
 requirements.txt
 image.tar
 scratch/
+.scratch/
 
 
 .claude/

--- a/padmy/db.py
+++ b/padmy/db.py
@@ -127,11 +127,15 @@ class Table:
     def count(self, v: int):
         self._count = v
 
-    def get_values(self, table: str | None = None):
+    @property
+    def insert_columns(self) -> list[str]:
         if self.columns is None:
             raise ValueError("Columns must be loaded first")
+        return sorted(x.name for x in self.columns if not x.is_generated)
+
+    def get_values(self, table: str | None = None):
         _table = f"{table}." if table is not None else ""
-        return ", ".join(sorted([f'{_table}"{x.name}"' for x in self.columns if not x.is_generated]))
+        return ", ".join(f'{_table}"{name}"' for name in self.insert_columns)
 
     @property
     def values(self):

--- a/padmy/sampling/sampling.py
+++ b/padmy/sampling/sampling.py
@@ -1,5 +1,7 @@
+import asyncio
 import contextlib
 import tempfile
+from collections.abc import Callable
 from math import floor
 from typing import cast, Literal
 
@@ -72,33 +74,32 @@ def copy_database(
             )
 
 
-def get_insert_child_fk_data_query(table: Table, child_table: Table) -> str:
+def get_insert_child_fk_data_queries(table: Table, child_table: Table) -> list[str]:
     """
-    Gets the query to insert data from a table to the temporary table.
+    Gets the queries inserting into the temporary table the rows of `table` that are
+    referenced by `child_table`'s temporary table, one query per foreign key.
+    Running each FK path as a semi-join (instead of chaining inner joins in a single
+    query) keeps the row count bounded by the table size and keeps rows referenced
+    by only some of the paths.
     """
-    joins = []
 
-    def _fk_join(tmp_name: str, fk: FKConstraint, fk_index: int) -> str:
-        return f"inner join {tmp_name} _s{fk_index} on " + " and ".join(
-            f"_s{fk_index}.{column_name} = t.{foreign_column_name}"
+    def _fk_exists(fk: FKConstraint) -> str:
+        conditions = " and ".join(
+            f"_s.{column_name} = t.{foreign_column_name}"
             for column_name, foreign_column_name in zip(fk.column_names, fk.foreign_column_names)
         )
+        return f"where exists(select from {child_table.tmp_name} _s where {conditions})"
 
-    for i, _fk in enumerate(child_table.foreign_keys):
-        if _fk.foreign_full_name != table.full_name:
-            continue
-        joins.append(_fk_join(child_table.tmp_name, _fk, i))
-
-    query = (
+    return [
         f"""
     INSERT INTO {table.tmp_name} ({table.values})
     SELECT {table.get_values("t")} from {table.full_name} t
+    {_fk_exists(_fk)}
+    ON CONFLICT DO NOTHING
     """
-        + "\n".join(joins)
-        + "\n ON CONFLICT DO NOTHING"
-    )
-
-    return query
+        for _fk in child_table.foreign_keys
+        if _fk.foreign_full_name == table.full_name
+    ]
 
 
 def get_insert_data_query(table: Table):
@@ -113,17 +114,28 @@ def get_insert_data_query(table: Table):
     return query
 
 
-async def _insert_leaf_table(conn: asyncpg.Connection, table: Table, table_size: int):
+async def _insert_full_table(conn: asyncpg.Connection, table: Table):
     query = f"CREATE TEMP TABLE {table.tmp_name} ON COMMIT DROP AS SELECT * from {table.full_name}"
-    args = []
-    # if table_size > 0:
+    logs.debug(f"Full copy query: {query}")
+    await conn.execute(query)
+
+
+async def _insert_leaf_table(conn: asyncpg.Connection, table: Table, table_size: int):
+    if table_size >= table.count:
+        await _insert_full_table(conn, table)
+        return
+    query = f"CREATE TEMP TABLE {table.tmp_name} ON COMMIT DROP AS SELECT * from {table.full_name}"
     query = f"{query} TABLESAMPLE SYSTEM_ROWS($1)"
-    args.append(table_size)
-    logs.debug(f"{query} {args}")
-    await conn.execute(query, *args)
+    logs.debug(f"{query} [{table_size}]")
+    await conn.execute(query, table_size)
 
 
 async def _insert_node_table(conn: asyncpg.Connection, table: Table, table_size: int):
+    # sample=100: a full copy satisfies every child FK, no need for the closure joins
+    if table_size >= table.count:
+        await _insert_full_table(conn, table)
+        return
+
     # Creating the table
     query = f"CREATE TEMP TABLE {table.tmp_name} (LIKE {table.full_name} INCLUDING ALL) ON COMMIT DROP"
     logs.debug(f"Create node table query: {query}")
@@ -131,9 +143,9 @@ async def _insert_node_table(conn: asyncpg.Connection, table: Table, table_size:
 
     # Inserting data from child table
     for _child_table in table.child_tables_safe:
-        query = get_insert_child_fk_data_query(table, _child_table)
-        logs.debug(f"Insert child data query: {query}")
-        await conn.execute(query)
+        for query in get_insert_child_fk_data_queries(table, _child_table):
+            logs.debug(f"Insert child data query: {query}")
+            await conn.execute(query)
 
     count = cast(int | None, await conn.fetchval(f"SELECT count(*) from {table.tmp_name}"))
     if count is None:
@@ -245,6 +257,52 @@ async def create_temp_tables(
         _tables = _parent_tables
 
 
+async def copy_table_data(
+    conn: asyncpg.Connection,
+    target_conn: asyncpg.Connection,
+    table: Table,
+    *,
+    on_rows_copied: Callable[[int], None] | None = None,
+):
+    """
+    Streams the content of the table's temporary table into the target database
+    using COPY on both sides. `on_rows_copied` is called with the (approximate)
+    number of rows in each streamed chunk.
+    """
+    queue: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=16)
+
+    async def _sink(data: bytes):
+        await queue.put(bytes(data))
+
+    async def _produce():
+        try:
+            await conn.copy_from_query(f"SELECT {table.values} from {table.tmp_name}", output=_sink)
+        finally:
+            await queue.put(None)
+
+    async def _chunks():
+        while (chunk := await queue.get()) is not None:
+            if on_rows_copied is not None:
+                # In COPY text format, unescaped newlines only terminate rows
+                on_rows_copied(chunk.count(b"\n"))
+            yield chunk
+
+    producer = asyncio.create_task(_produce())
+    try:
+        await target_conn.copy_to_table(
+            table.table,
+            source=_chunks(),
+            columns=table.insert_columns,
+            schema_name=table.schema,
+        )
+    except BaseException:
+        producer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await producer
+        raise
+    await producer
+
+
 async def sample_database(
     conn: asyncpg.Connection,
     target_conn: asyncpg.Connection,
@@ -254,6 +312,9 @@ async def sample_database(
     chunk_size: int = 5_000,
     # Deactivate triggers on reinserting to new database
     no_trigger: bool = True,
+    # Transfer using COPY. Set to False to fall back to chunked inserts
+    # with ON CONFLICT DO NOTHING (eg. if the target tables are not empty)
+    use_copy: bool = True,
 ):
     """
     From top table to bottom
@@ -301,17 +362,23 @@ async def sample_database(
                     logs.debug(f"Inserting to {table.full_name}")
                     if task2 is not None:
                         progress.reset(task2, total=_table_count[table.tmp_name])
-                    query = f"SELECT {table.values} from {table.tmp_name}"
 
-                    async for chunk in iterate_pg(conn, query, chunk_size=chunk_size):
-                        logs.debug(f"{table.full_name} ({len(chunk)})")
-                        await insert_many(
-                            target_conn,
-                            table.full_name,
-                            [dict(x) for x in chunk],
-                            on_conflict="ON CONFLICT DO NOTHING",
-                            quote_columns=True,
+                    if use_copy:
+                        _on_rows_copied = (
+                            (lambda nb_rows: progress.update(task2, advance=nb_rows)) if task2 is not None else None
                         )
-                        if task2 is not None:
-                            progress.update(task2, advance=chunk_size)
+                        await copy_table_data(conn, target_conn, table, on_rows_copied=_on_rows_copied)
+                    else:
+                        query = f"SELECT {table.values} from {table.tmp_name}"
+                        async for chunk in iterate_pg(conn, query, chunk_size=chunk_size):
+                            logs.debug(f"{table.full_name} ({len(chunk)})")
+                            await insert_many(
+                                target_conn,
+                                table.full_name,
+                                [dict(x) for x in chunk],
+                                on_conflict="ON CONFLICT DO NOTHING",
+                                quote_columns=True,
+                            )
+                            if task2 is not None:
+                                progress.update(task2, advance=chunk_size)
                     progress.update(task1, advance=1)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -223,6 +223,44 @@ def setup_3_simple_tables(engine, sample_engine):
     sample_engine.commit()
 
 
+@pytest.fixture()
+def setup_multi_fk_tables(engine, sample_engine):
+    query = """
+    DROP SCHEMA IF EXISTS tmptest CASCADE;
+    CREATE SCHEMA tmptest;
+    CREATE TABLE IF NOT EXISTS tmptest.table_1
+    (
+        id  SERIAL PRIMARY KEY,
+        foo TEXT NOT NULL
+    );
+
+    -- Two FK paths to the same parent (new table name to avoid reusing the
+    -- session connection's cached statements on a different table shape)
+    CREATE TABLE IF NOT EXISTS tmptest.table_4
+    (
+        id            SERIAL PRIMARY KEY,
+        table_1_id    INT REFERENCES tmptest.table_1 ON DELETE CASCADE,
+        table_1_bis_id INT REFERENCES tmptest.table_1 ON DELETE CASCADE
+    );
+    """
+    engine.execute(query)
+    engine.commit()
+    table_1 = [
+        {
+            "id": i,
+            "foo": f"foo-{i}",
+        }
+        for i in range(10)
+    ]
+    table_4 = [{"id": 0, "table_1_id": 0, "table_1_bis_id": 1}]
+
+    insert_many(engine, "tmptest.table_1", table_1)
+    insert_many(engine, "tmptest.table_4", table_4)
+
+    sample_engine.execute(query)
+    sample_engine.commit()
+
+
 @pytest.mark.parametrize(
     "patch_scenario, sample_size, expected",
     [
@@ -263,6 +301,18 @@ def setup_3_simple_tables(engine, sample_engine):
                 "_tmptest_table_3_tmp": [],
             },
             id="3 tables, parent sample too small",
+        ),
+        pytest.param(
+            "setup_multi_fk_tables",
+            {
+                "tmptest.table_1": 0,
+                "tmptest.table_4": 100,
+            },
+            {
+                "_tmptest_table_1_tmp": [{"id": 0, "foo": "foo-0"}, {"id": 1, "foo": "foo-1"}],
+                "_tmptest_table_4_tmp": [{"id": 0, "table_1_id": 0, "table_1_bis_id": 1}],
+            },
+            id="2 fk paths to the same parent, both referenced parents kept",
         ),
     ],
 )


### PR DESCRIPTION
## Summary

- Fix the `sample` pathology that wedged a 6.5 GB production run for 69+ minutes: parent tables reachable through several FK paths of the same child (e.g. `entities` ← `contracts.entity_id` / `contracts.supplier_entity_id`) were built with all paths chained as `INNER JOIN`s in one INSERT, multiplying matches per parent row (quadratic in data size) — and dropping parents referenced via only one path, which left FK-orphaned children in the sample.
- Short-circuit `sample: 100` tables to a plain `CREATE TEMP TABLE … AS SELECT`: a full copy trivially satisfies every child FK, so the closure walk is skipped entirely (the incident config sampled everything at 100%).
- Transfer temp tables to the target with `COPY` streamed between the two connections instead of chunked `insert_many` (~10× faster).

## Changes

- `get_insert_child_fk_data_queries` now emits one `INSERT … WHERE EXISTS` semi-join per foreign key: output is bounded by the parent row count, and union semantics keep every referenced parent.
- `_insert_leaf_table` / `_insert_node_table` fall back to a full copy when `table_size >= count` (no `TABLESAMPLE`, no joins, no top-up).
- New `copy_table_data` streams `COPY TO STDOUT` → `COPY FROM STDIN` through a bounded queue; row-level progress is kept by counting rows in the COPY text stream. `sample_database(…, use_copy=False)` preserves the previous `ON CONFLICT DO NOTHING` insert path for pre-populated targets.
- `Table.insert_columns` exposes the non-generated column list (shared by `get_values` and the COPY column list).
- Regression test: two FK paths to the same parent — fails on the old query shape, passes now.
- `.gitignore`: add `.scratch/` (the standalone uv benchmark reproducing the incident lives there, out of the repo).

## Timings

| Phase (synthetic incident schema, 1/10 scale) | before | after |
|---|---|---|
| temp tables, `sample: 100` | 27.8 s | 0.05 s |
| temp tables, `sample: 10` | 20.4 s | 0.15 s |
| transfer ~385k rows | 4.2 s | 0.4 s |
| real track-backend schema, full CLI, `sample: 100` | killed at 9.5 min | 7.8 s |

FK integrity verified on the real schema: 249 constraints, 0 orphans at 100% and 30%.
