### PR TITLE
fix(anonymize): composite-type casts, varchar overflow, masked table errors

### DIFF
--- a/padmy/anonymize/anonymize.py
+++ b/padmy/anonymize/anonymize.py
@@ -71,10 +71,6 @@ def gen_mock_data(faker: Faker, fields: list[AnoFields], size: int) -> Iterator[
         yield {v.column: _get_fake_value(faker.unique if v.unique else faker, v.type, v.extra_args) for v in fields}
 
 
-def dict_to_tuple(d: dict, fields: list[str]) -> tuple:
-    return tuple(d[k] for k in fields)
-
-
 async def anonymize_table(
     conn: asyncpg.Connection,
     table: ConfigTable,
@@ -92,28 +88,35 @@ async def anonymize_table(
 
     fields = [x.column for x in table.fields]
     columns_type = await load_columns_type(conn, table.schema, table.table, pks + fields)
-    update_query = get_update_query(table.full_name, pks, fields, {k: v.sql_type for k, v in columns_type.items()})
-    max_lengths = {k: v.max_length for k, v in columns_type.items() if v.max_length is not None}
+    sql_types: dict[str, str] = {}
+    max_lengths: dict[str, int] = {}
+    for _column, _type in columns_type.items():
+        sql_types[_column] = _type.sql_type
+        if _type.max_length is not None:
+            max_lengths[_column] = _type.max_length
+    update_query = get_update_query(table.full_name, pks, fields, sql_types)
 
     _warned: set[str] = set()
 
-    def _fit(row: dict) -> dict:
+    def _fit(field: str, value: Any) -> Any:
         """Truncates generated strings to the column's max length (eg. phone numbers in varchar(15))."""
-        for k, v in row.items():
-            _max_length = max_lengths.get(k)
-            if _max_length is not None and isinstance(v, str) and len(v) > _max_length:
-                if k not in _warned:
-                    _warned.add(k)
-                    logs.warning(f"{table.full_name}.{k}: truncating generated values to {_max_length} chars")
-                row[k] = v[:_max_length]
-        return row
+        _max_length = max_lengths.get(field)
+        if _max_length is None or not isinstance(value, str) or len(value) <= _max_length:
+            return value
+        if field not in _warned:
+            _warned.add(field)
+            logs.warning(f"{table.full_name}.{field}: truncating generated values to {_max_length} chars")
+        return value[:_max_length]
+
+    def _to_row(pk_values: asyncpg.Record, mock: dict) -> tuple:
+        return tuple(pk_values[k] for k in pks) + tuple(_fit(k, mock[k]) for k in fields)
 
     async with conn.transaction():
         # aclosing so the cursor generator is closed on error while the connection is still usable
         async with contextlib.aclosing(iterate_pg(conn, query, chunk_size=chunk_size)) as chunks:
             async for chunk in chunks:
-                mock_data = gen_mock_data(faker, fields=table.fields, size=chunk_size)
-                new_data = [dict_to_tuple({**c, **_fit(m)}, pks + fields) for c, m in zip(chunk, mock_data)]
+                mock_data = gen_mock_data(faker, fields=table.fields, size=len(chunk))
+                new_data = [_to_row(c, m) for c, m in zip(chunk, mock_data)]
                 await conn.executemany(update_query, new_data)
 
 

--- a/padmy/anonymize/anonymize.py
+++ b/padmy/anonymize/anonymize.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import itertools
 import operator
 from functools import partial
@@ -90,14 +91,30 @@ async def anonymize_table(
     query = f"SELECT {', '.join(pks)} from {table.schema}.{table.table}"
 
     fields = [x.column for x in table.fields]
-    fields_types = await load_columns_type(conn, table.schema, table.table, pks + fields)
-    update_query = get_update_query(table.full_name, pks, fields, fields_types)
+    columns_type = await load_columns_type(conn, table.schema, table.table, pks + fields)
+    update_query = get_update_query(table.full_name, pks, fields, {k: v.sql_type for k, v in columns_type.items()})
+    max_lengths = {k: v.max_length for k, v in columns_type.items() if v.max_length is not None}
+
+    _warned: set[str] = set()
+
+    def _fit(row: dict) -> dict:
+        """Truncates generated strings to the column's max length (eg. phone numbers in varchar(15))."""
+        for k, v in row.items():
+            _max_length = max_lengths.get(k)
+            if _max_length is not None and isinstance(v, str) and len(v) > _max_length:
+                if k not in _warned:
+                    _warned.add(k)
+                    logs.warning(f"{table.full_name}.{k}: truncating generated values to {_max_length} chars")
+                row[k] = v[:_max_length]
+        return row
 
     async with conn.transaction():
-        async for chunk in iterate_pg(conn, query, chunk_size=chunk_size):
-            mock_data = gen_mock_data(faker, fields=table.fields, size=chunk_size)
-            new_data = [dict_to_tuple({**c, **m}, pks + fields) for c, m in zip(chunk, mock_data)]
-            await conn.executemany(update_query, new_data)
+        # aclosing so the cursor generator is closed on error while the connection is still usable
+        async with contextlib.aclosing(iterate_pg(conn, query, chunk_size=chunk_size)) as chunks:
+            async for chunk in chunks:
+                mock_data = gen_mock_data(faker, fields=table.fields, size=chunk_size)
+                new_data = [dict_to_tuple({**c, **_fit(m)}, pks + fields) for c, m in zip(chunk, mock_data)]
+                await conn.executemany(update_query, new_data)
 
 
 async def anonymize_db(pool: asyncpg.Pool, config: Config, faker: Faker):
@@ -115,7 +132,9 @@ async def anonymize_db(pool: asyncpg.Pool, config: Config, faker: Faker):
         for _table_name, _table_pks in itertools.groupby(pks, operator.attrgetter("full_name"))
     }
 
-    await asyncio.gather(
+    # return_exceptions so one failing table does not cancel the others mid-query
+    # (cancellation used to surface as a misleading InterfaceError on pool release)
+    results = await asyncio.gather(
         *[
             get_conn(
                 pool,
@@ -127,5 +146,13 @@ async def anonymize_db(pool: asyncpg.Pool, config: Config, faker: Faker):
                 ),
             )
             for _table in _tables_to_anonymize
-        ]
+        ],
+        return_exceptions=True,
     )
+    errors = {
+        _table.full_name: _res for _table, _res in zip(_tables_to_anonymize, results) if isinstance(_res, BaseException)
+    }
+    for _table_name, _error in errors.items():
+        logs.error(f"Could not anonymize {_table_name!r}: {_error!r}")
+    if errors:
+        raise BaseExceptionGroup(f"Could not anonymize {len(errors)} table(s)", list(errors.values()))

--- a/padmy/db.py
+++ b/padmy/db.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import functools
 import sys
 from dataclasses import dataclass, field
 
@@ -262,19 +261,36 @@ async def load_primary_keys(conn: PgConnection, schemas: list[str]):
     return [PKConstraint(**x) for x in data]
 
 
+# format_type gives a valid SQL type expression (composite types, arrays, varchar(n), ...),
+# unlike information_schema.columns.data_type which yields literals like 'USER-DEFINED'
 GET_COLUMNS_TYPE_QUERY = """
-SELECT 
-    column_name, data_type 
-FROM information_schema.columns 
-WHERE table_schema = $1 AND 
-      table_name = $2 AND 
-      column_name = ANY ($3::TEXT[])
+SELECT a.attname                            AS column_name,
+       format_type(a.atttypid, a.atttypmod) AS data_type,
+       CASE
+           WHEN a.atttypid IN ('varchar'::regtype, 'bpchar'::regtype) AND a.atttypmod > 4
+               THEN a.atttypmod - 4
+           END                              AS max_length
+FROM pg_catalog.pg_attribute a
+JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = $1
+  AND c.relname = $2
+  AND a.attname = ANY ($3::TEXT[])
+  AND a.attnum > 0
+  AND NOT a.attisdropped
 """
+
+
+@dataclass
+class ColumnType:
+    sql_type: str
+    # character maximum length for varchar(n)/char(n) columns, None otherwise
+    max_length: int | None = None
 
 
 async def load_columns_type(conn: asyncpg.Connection, schema: str, table: str, columns: list[str]):
     data = await conn.fetch(GET_COLUMNS_TYPE_QUERY, schema, table, columns)
-    return functools.reduce(lambda p, n: {**p, **{n["column_name"]: n["data_type"]}}, data, {})
+    return {x["column_name"]: ColumnType(sql_type=x["data_type"], max_length=x["max_length"]) for x in data}
 
 
 @dataclass

--- a/padmy/run.py
+++ b/padmy/run.py
@@ -51,10 +51,11 @@ async def ano_main(
     pg_infos: PGConnectionInfo = Derived(get_pg_infos),
     db_name: str = Option(..., "--db", help="Database to anonymize"),
     config_path: Path = Option(..., "-f", "--file", help="Path to the configuration file"),
+    locale: str | None = Option(None, "--locale", help="Faker locale used to generate fake data (eg. fr_FR)"),
 ):
     if Faker is None:
         raise ImportError('Please install faker or padmy with "anonymize" to use this module')
-    faker = Faker()
+    faker = Faker(locale)
 
     config = Config.load_from_file(config_path)
     async with pg_infos.get_pool(db_name) as pool:

--- a/padmy/utils.py
+++ b/padmy/utils.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from functools import partial
 from importlib import reload
 from pathlib import Path
-from typing import Sequence, AsyncIterator, Callable, TypeVar, cast, Literal
+from typing import Sequence, AsyncGenerator, AsyncIterator, Callable, TypeVar, cast, Literal
 
 import asyncpg
 from asyncpg import Connection
@@ -359,7 +359,7 @@ async def iterate_pg(
     from_offset: int = 0,
     chunk_size: int = 500,
     timeout: int | None = None,
-) -> AsyncIterator[list[asyncpg.Record]]:
+) -> AsyncGenerator[list[asyncpg.Record], None]:
     async with conn.transaction():
         cur: asyncpg.connection.cursor.Cursor = await conn.cursor(query, *args)
         if from_offset:

--- a/tests/test_anonymize.py
+++ b/tests/test_anonymize.py
@@ -78,6 +78,65 @@ def test_anonymize_table(aengine, loop, engine, faker):
     ]
 
 
+@pytest.fixture()
+def setup_ano_types_table(engine):
+    engine.execute(
+        """
+        DROP TABLE IF EXISTS public.ano_types;
+        DROP TYPE IF EXISTS public.ano_address;
+        CREATE TYPE public.ano_address AS (street TEXT, zipcode TEXT);
+        CREATE TABLE public.ano_types
+        (
+            id    SERIAL PRIMARY KEY,
+            addr  public.ano_address,
+            phone VARCHAR(15)
+        );
+        """
+    )
+    insert_many(engine, "public.ano_types", [{"id": i, "phone": "0611223344"} for i in range(5)])
+    engine.execute("UPDATE public.ano_types SET addr = ('street', 'zip')::public.ano_address")
+    engine.commit()
+    yield
+    engine.execute("DROP TABLE IF EXISTS public.ano_types; DROP TYPE IF EXISTS public.ano_address")
+    engine.commit()
+
+
+@pytest.mark.usefixtures("setup_ano_types_table")
+def test_load_columns_type(aengine, loop):
+    """format_type-based introspection returns castable types (not 'USER-DEFINED') and varchar max lengths."""
+    from padmy.db import load_columns_type, ColumnType
+
+    types = loop.run_until_complete(load_columns_type(aengine, "public", "ano_types", ["id", "addr", "phone"]))
+    assert types == {
+        "id": ColumnType("integer"),
+        "addr": ColumnType("ano_address"),
+        "phone": ColumnType("character varying(15)", max_length=15),
+    }
+
+
+@pytest.mark.usefixtures("setup_ano_types_table")
+def test_anonymize_table_composite_and_max_length(aengine, loop, engine, faker):
+    """Composite-typed columns get a valid cast and generated values are truncated to fit varchar(n)."""
+    from padmy.anonymize.anonymize import anonymize_table
+    from padmy.config import ConfigTable, AnoFields
+
+    table = ConfigTable(
+        "public",
+        "ano_types",
+        fields=[
+            AnoFields(column="addr", type="NULL"),
+            AnoFields(column="phone", type="PHONE_NUMBER"),
+        ],
+    )
+
+    loop.run_until_complete(anonymize_table(aengine, table, ["id"], faker))
+
+    db = fetch_all(engine, "SELECT addr, phone FROM public.ano_types")
+    assert len(db) == 5
+    assert all(x["addr"] is None for x in db)
+    assert all(x["phone"] and len(x["phone"]) <= 15 and x["phone"] != "0611223344" for x in db)
+
+
 @pytest.mark.parametrize(
     "field_type, extra, predicate",
     [
@@ -147,3 +206,25 @@ def test_anonymize_db(apool, engine, loop, faker):
         {"foo": "achang@my-domain.fr", "id": 1},
         {"foo": "greenwilliam@my-domain.fr", "id": 2},
     ]
+
+
+@pytest.mark.usefixtures("add_table_1_data")
+def test_anonymize_db_surfaces_table_errors(apool, engine, loop, faker):
+    """A failing table raises an explicit error and does not prevent the other tables from completing."""
+    from padmy.anonymize import anonymize_db
+    from padmy.config import Config, ConfigTable, AnoFields
+
+    config = Config(
+        tables=[
+            ConfigTable("public", "table_1", fields=[AnoFields(column="foo", type="EMAIL")]),
+            ConfigTable("public", "table_1", fields=[AnoFields(column="does_not_exist", type="EMAIL")]),
+        ]
+    )
+
+    with pytest.raises(ExceptionGroup, match="Could not anonymize 1 table") as exc_info:
+        loop.run_until_complete(anonymize_db(apool, config, faker))
+
+    assert len(exc_info.value.exceptions) == 1
+
+    db = fetch_all(engine, "SELECT foo FROM public.table_1")
+    assert all("@" in x["foo"] for x in db)


### PR DESCRIPTION
Fixes three bugs found running `padmy anonymize` against a real multi-schema PG17 database (11 tables / ~25 anonymized fields).

## 1. Composite-type columns produced invalid SQL casts
`load_columns_type` used `information_schema.columns.data_type`, which returns the literal `USER-DEFINED` for composite-typed columns (and `ARRAY` for arrays), producing casts like `$5::USER-DEFINED` — a syntax error even for `type: "NULL"` fields. Column types are now introspected from `pg_catalog` with `format_type(atttypid, atttypmod)`, which always yields a valid, schema-qualified-when-needed SQL type expression.

## 2. Generated values overflowed length-limited columns
Faker's default `en_US` `phone_number()` can produce ~21 chars, overflowing e.g. `varchar(15)` with `StringDataRightTruncationError`. Two layers:
- `padmy anonymize` gains a `--locale` option passed to `Faker`.
- The type introspection also returns the character maximum length for `varchar(n)`/`char(n)`, and generated strings are truncated to fit (one-time warning per column). This matters even with `fr_FR`, some of whose phone formats also exceed 15 chars.

## 3. Real errors were masked by teardown noise
`anonymize_db` ran all tables via bare `asyncio.gather`: one failing UPDATE cancelled sibling tasks mid-query and the process died with a misleading `InterfaceError: cannot perform operation: another operation is in progress` from pool release, the actual SQL error at best buried in a "Task exception was never retrieved". Now:
- `gather(..., return_exceptions=True)` lets healthy tables complete,
- each failing table is logged explicitly (`Could not anonymize 'schema.table': ...`),
- an `ExceptionGroup` with the real errors is raised (non-zero exit),
- the cursor generator is closed deterministically (`contextlib.aclosing`) while the connection is still usable, instead of at GC time on a released connection.

## Tests
- `load_columns_type` on a table with composite + `varchar(15)` columns (asserts castable types and max length),
- end-to-end `anonymize_table` on that table (`NULL` composite, truncated `PHONE_NUMBER`),
- `anonymize_db` with one healthy and one broken table (asserts the `ExceptionGroup` surfaces and the healthy table is still anonymized).

Also verified with the real CLI against the original repro (composite `utils.address` + `varchar(15)` phone): exits 0 with correct data; the broken-config variant exits 1 with the real `KeyError` visible and no `InterfaceError` noise.